### PR TITLE
Implement admin /addtask command

### DIFF
--- a/src/main/java/com/example/duolingomathbot/service/UserTrainingService.java
+++ b/src/main/java/com/example/duolingomathbot/service/UserTrainingService.java
@@ -186,4 +186,33 @@ public class UserTrainingService {
         user.incrementTrainingCounter();
         userRepository.save(user);
     }
+
+    @Transactional(readOnly = true)
+    public List<Topic> getAllTopics() {
+        return topicRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Topic> getTopic(Long id) {
+        return topicRepository.findById(id);
+    }
+
+    @Transactional
+    public Task addTask(Long topicId, String content, String answer) {
+        Topic topic = topicRepository.findById(topicId)
+                .orElseThrow(() -> new IllegalArgumentException("Topic not found with ID: " + topicId));
+        Task task = new Task(topic, content, answer, 1.0);
+        return taskRepository.save(task);
+    }
+
+    @Transactional
+    public Topic createTopic(String name) {
+        if (topicRepository.findByName(name).isPresent()) {
+            throw new IllegalArgumentException("Topic already exists: " + name);
+        }
+        Topic topic = new Topic();
+        topic.setName(name);
+        topic.setMaxDifficultyInTopic(1.0);
+        return topicRepository.save(topic);
+    }
 }


### PR DESCRIPTION
## Summary
- add `/train` command and keep `/start` for greeting
- improve admin `/addtask` flow with topic list and "Новая тема" button
- handle invalid topic id during task creation
- show only task image/text with prompt when training
- expose `getTopic` service method

## Testing
- `./gradlew build -x test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68545ff1a1488326add3555ac75f89b7