### PR TITLE
Add admin chat config

### DIFF
--- a/src/main/java/com/example/duolingomathbot/bot/BotConfig.java
+++ b/src/main/java/com/example/duolingomathbot/bot/BotConfig.java
@@ -24,11 +24,18 @@ public class BotConfig {
     @Value("${telegram.bot.token}")
     private String botToken;
 
+    @Value("${telegram.admin-chat-id}")
+    private long adminChatId;
+
     public String getBotUsername() {
         return botUsername;
     }
 
     public String getBotToken() {
         return botToken;
+    }
+
+    public long getAdminChatId() {
+        return adminChatId;
     }
 }

--- a/src/main/java/com/example/duolingomathbot/bot/MathSrTelegramBot.java
+++ b/src/main/java/com/example/duolingomathbot/bot/MathSrTelegramBot.java
@@ -41,7 +41,7 @@ public class MathSrTelegramBot extends TelegramLongPollingBot {
     // Это для оптимизации, чтобы не дергать БД каждый раз за internalUserId
     private final ConcurrentHashMap<Long, Long> telegramToInternalUserIdMap = new ConcurrentHashMap<>();
 
-    private static final long ADMIN_CHAT_ID = 262398881L;
+    private final long adminChatId;
 
     private enum AddTaskStep {
         WAITING_FOR_PHOTO,
@@ -63,6 +63,7 @@ public class MathSrTelegramBot extends TelegramLongPollingBot {
         super(botConfig.getBotToken());
         this.botConfig = botConfig;
         this.userTrainingService = userTrainingService;
+        this.adminChatId = botConfig.getAdminChatId();
     }
 
     @Override
@@ -171,7 +172,7 @@ public class MathSrTelegramBot extends TelegramLongPollingBot {
         }
 
         if ("/addtask".equals(messageText)) {
-            if (chatId != ADMIN_CHAT_ID) {
+            if (chatId != adminChatId) {
                 sendMessage(chatId, "Команда доступна только администратору");
                 return;
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,6 +51,9 @@ telegram.bot.username=gnedash_as_bot
 # ????? ?????? Telegram ???? (?????????? ? @BotFather)
 telegram.bot.token=6728182225:AAG-lNuM-ByCd8Fc9musFIoXJ5M86sUv-1c
 
+# Chat ID администратора, которому доступна команда /addtask
+telegram.admin-chat-id=262398881
+
 # =======================================
 # Logging Configuration
 # =======================================


### PR DESCRIPTION
## Summary
- add `telegram.admin-chat-id` property
- inject admin chat ID via `BotConfig`
- pass configurable admin chat ID to `MathSrTelegramBot`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856c3351e5c83269f3080e7c115e6b1