### PR TITLE
Add admin panel with task upload

### DIFF
--- a/src/main/java/com/example/duolingomathbot/config/SrsConfig.java
+++ b/src/main/java/com/example/duolingomathbot/config/SrsConfig.java
@@ -9,4 +9,5 @@ public class SrsConfig {
     public static final List<Integer> SRS_STAGES_INTERVALS = Arrays.asList(1, 3, 7, 14, 21, 30, 60);
     public static final int MIN_HARD_TASKS_FOR_TOPIC_COMPLETION = 5;
     public static final double HARD_TASK_DIFFICULTY_THRESHOLD_FACTOR = 0.8;
+    public static final double MEDIUM_TASK_DIFFICULTY_THRESHOLD_FACTOR = 0.5;
 }

--- a/src/main/java/com/example/duolingomathbot/controller/AdminController.java
+++ b/src/main/java/com/example/duolingomathbot/controller/AdminController.java
@@ -1,0 +1,41 @@
+package com.example.duolingomathbot.controller;
+
+import com.example.duolingomathbot.model.Task;
+import com.example.duolingomathbot.model.Topic;
+import com.example.duolingomathbot.service.UserTrainingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    @Autowired
+    private UserTrainingService userTrainingService;
+
+    @GetMapping("/topics")
+    public List<Topic> getTopics() {
+        return userTrainingService.getAllTopics();
+    }
+
+    @PostMapping("/task")
+    public ResponseEntity<?> addTask(@RequestParam Long topicId,
+                                     @RequestParam String answer,
+                                     @RequestParam("image") MultipartFile image) {
+        try {
+            String base64 = Base64.getEncoder().encodeToString(image.getBytes());
+            Task task = userTrainingService.addTask(topicId, "DATA:" + base64, answer);
+            return ResponseEntity.ok(task.getId());
+        } catch (IOException e) {
+            return ResponseEntity.badRequest().body("Ошибка загрузки файла");
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("Ошибка сохранения задачи");
+        }
+    }
+}

--- a/src/main/java/com/example/duolingomathbot/repository/TopicRepository.java
+++ b/src/main/java/com/example/duolingomathbot/repository/TopicRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TopicRepository extends JpaRepository<Topic, Long> {
-    @Query("SELECT t FROM Topic t WHERE t.id NOT IN (SELECT utp.topic.id FROM UserTopicProgress utp WHERE utp.user.id = :userId)")
+    @Query("SELECT t FROM Topic t WHERE t.id NOT IN (SELECT utp.topic.id FROM UserTopicProgress utp WHERE utp.user.id = :userId) ORDER BY t.id")
     List<Topic> findUnstartedTopicsForUser(@Param("userId") Long userId);
 
     Optional<Topic> findByName(String name);

--- a/src/main/java/com/example/duolingomathbot/service/UserTrainingService.java
+++ b/src/main/java/com/example/duolingomathbot/service/UserTrainingService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -98,8 +97,7 @@ public class UserTrainingService {
 
         List<Topic> unstartedTopics = topicRepository.findUnstartedTopicsForUser(user.getId());
         if (!unstartedTopics.isEmpty()) {
-            Collections.shuffle(unstartedTopics);
-            Topic newTopic = unstartedTopics.get(0);
+            Topic newTopic = unstartedTopics.get(0); // predetermined order
             UserTopicProgress newProgress = new UserTopicProgress(user, newTopic);
             userTopicProgressRepository.save(newProgress);
 

--- a/src/main/resources/static/admin.html
+++ b/src/main/resources/static/admin.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Panel</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        #panel button { display: block; margin: 0.5em 0; }
+        #addTaskForm { margin-top: 1em; }
+    </style>
+</head>
+<body>
+<h1>Админ панель</h1>
+<div id="login">
+    <label>Пароль: <input type="password" id="password"></label>
+    <button id="loginBtn">Войти</button>
+</div>
+<div id="panel" style="display:none;">
+    <button id="statsBtn">Посмотреть статистику</button>
+    <button id="tasksBtn">Посмотреть банк задач</button>
+    <button id="topicsBtn">Посмотреть темы</button>
+    <button id="addTopicBtn">Добавить тему</button>
+    <button id="addTaskBtn">Добавить задачу</button>
+</div>
+<div id="addTaskForm" style="display:none;">
+    <input type="file" id="taskImage" accept="image/*"><br>
+    <label>Ответ: <input type="text" id="taskAnswer"></label><br>
+    <label>Тема: <select id="topicSelect"></select></label><br>
+    <button id="saveTaskBtn">Сохранить задачу</button>
+</div>
+<script>
+const adminPassword = '262398881';
+
+const loginBtn = document.getElementById('loginBtn');
+const panel = document.getElementById('panel');
+const loginDiv = document.getElementById('login');
+loginBtn.onclick = function() {
+    const pass = document.getElementById('password').value;
+    if (pass === adminPassword) {
+        loginDiv.style.display = 'none';
+        panel.style.display = 'block';
+    } else {
+        alert('Неверный пароль');
+    }
+};
+
+document.getElementById('addTaskBtn').onclick = function() {
+    panel.style.display = 'none';
+    document.getElementById('addTaskForm').style.display = 'block';
+    fetch('/api/admin/topics').then(r => r.json()).then(list => {
+        const select = document.getElementById('topicSelect');
+        select.innerHTML = '';
+        list.forEach(t => {
+            const o = document.createElement('option');
+            o.value = t.id;
+            o.textContent = t.name;
+            select.appendChild(o);
+        });
+    });
+};
+
+document.getElementById('saveTaskBtn').onclick = function() {
+    const file = document.getElementById('taskImage').files[0];
+    const answer = document.getElementById('taskAnswer').value;
+    const topicId = document.getElementById('topicSelect').value;
+    if (!file || !answer) { alert('Заполните все поля'); return; }
+    const formData = new FormData();
+    formData.append('image', file);
+    formData.append('answer', answer);
+    formData.append('topicId', topicId);
+    fetch('/api/admin/task', { method: 'POST', body: formData })
+        .then(r => r.text())
+        .then(msg => {
+            alert('Задача сохранена, id=' + msg);
+            document.getElementById('addTaskForm').style.display = 'none';
+            panel.style.display = 'block';
+        });
+};
+</script>
+</body>
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Duolingo Math Web Trainer</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        #task { margin-top: 1em; font-size: 1.2em; }
+        #controls { margin-top: 1em; }
+    </style>
+</head>
+<body>
+    <h1>Duolingo Math Web Trainer</h1>
+    <p><a href="admin.html">Админ панель</a></p>
+
+    <div id="registration">
+        <label>Telegram ID: <input type="number" id="telegramId"></label>
+        <label>Username: <input type="text" id="username"></label>
+        <button id="registerBtn">Register</button>
+    </div>
+
+    <div id="training" style="display:none;">
+        <button id="nextBtn">Get Next Task</button>
+        <div id="task"></div>
+        <div id="controls" style="display:none;">
+            <button id="correctBtn">Правильно</button>
+            <button id="incorrectBtn">Неправильно</button>
+        </div>
+        <div id="feedback"></div>
+    </div>
+
+    <script>
+        let userId = null;
+        let currentTaskId = null;
+        document.getElementById('registerBtn').onclick = function() {
+            const telegramId = document.getElementById('telegramId').value;
+            const username = document.getElementById('username').value || 'User_' + telegramId;
+            fetch('/api/training/user?telegramId=' + telegramId + '&username=' + encodeURIComponent(username), { method: 'POST'})
+                .then(r => r.json())
+                .then(u => {
+                    userId = u.id;
+                    document.getElementById('registration').style.display = 'none';
+                    document.getElementById('training').style.display = 'block';
+                });
+        };
+
+        document.getElementById('nextBtn').onclick = function() {
+            if (userId == null) return;
+            fetch('/api/training/next-task?userId=' + userId)
+                .then(r => r.json())
+                .then(task => {
+                    if (task.id) {
+                        currentTaskId = task.id;
+                        document.getElementById('task').textContent = task.content;
+                        document.getElementById('controls').style.display = 'block';
+                        document.getElementById('feedback').textContent = '';
+                    } else {
+                        document.getElementById('task').textContent = task;
+                        document.getElementById('controls').style.display = 'none';
+                        currentTaskId = null;
+                    }
+                });
+        };
+
+        function sendAnswer(isCorrect) {
+            fetch('/api/training/answer?userId=' + userId + '&taskId=' + currentTaskId + '&isCorrect=' + isCorrect, { method: 'POST' })
+                .then(r => r.text())
+                .then(msg => {
+                    document.getElementById('feedback').textContent = msg;
+                    document.getElementById('controls').style.display = 'none';
+                });
+        }
+
+        document.getElementById('correctBtn').onclick = () => sendAnswer(true);
+        document.getElementById('incorrectBtn').onclick = () => sendAnswer(false);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide admin HTML page requiring password login
- allow new tasks with image upload via `/api/admin/task`
- expose topics list for admin page
- link admin panel from index page

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856cc3d89488326925cdcf792c04a3b