### PR TITLE
Add topic management features

### DIFF
--- a/src/main/java/com/example/duolingomathbot/model/Topic.java
+++ b/src/main/java/com/example/duolingomathbot/model/Topic.java
@@ -17,11 +17,19 @@ public class Topic {
     @Column(name = "max_difficulty_in_topic", nullable = false)
     private double maxDifficultyInTopic = 1.0;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TopicType type = TopicType.OBA;
+
+    @Column(name = "order_index")
+    private Integer orderIndex;
+
     public Topic() {
     }
 
-    public Topic(String name, double maxDifficultyInTopic) {
+    public Topic(String name, TopicType type, double maxDifficultyInTopic) {
         this.name = name;
+        this.type = type;
         this.maxDifficultyInTopic = maxDifficultyInTopic;
     }
 
@@ -48,6 +56,22 @@ public class Topic {
 
     public void setMaxDifficultyInTopic(double maxDifficultyInTopic) {
         this.maxDifficultyInTopic = maxDifficultyInTopic;
+    }
+
+    public TopicType getType() {
+        return type;
+    }
+
+    public void setType(TopicType type) {
+        this.type = type;
+    }
+
+    public Integer getOrderIndex() {
+        return orderIndex;
+    }
+
+    public void setOrderIndex(Integer orderIndex) {
+        this.orderIndex = orderIndex;
     }
 
     @Override

--- a/src/main/java/com/example/duolingomathbot/model/TopicType.java
+++ b/src/main/java/com/example/duolingomathbot/model/TopicType.java
@@ -1,0 +1,22 @@
+package com.example.duolingomathbot.model;
+
+public enum TopicType {
+    OGE("ОГЭ"),
+    EGE("ЕГЭ"),
+    OBA("ОБА");
+
+    private final String displayName;
+
+    TopicType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/example/duolingomathbot/repository/TopicRepository.java
+++ b/src/main/java/com/example/duolingomathbot/repository/TopicRepository.java
@@ -9,8 +9,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TopicRepository extends JpaRepository<Topic, Long> {
-    @Query("SELECT t FROM Topic t WHERE t.id NOT IN (SELECT utp.topic.id FROM UserTopicProgress utp WHERE utp.user.id = :userId) ORDER BY t.id")
+    @Query("SELECT t FROM Topic t WHERE t.id NOT IN (SELECT utp.topic.id FROM UserTopicProgress utp WHERE utp.user.id = :userId) " +
+            "ORDER BY CASE WHEN t.orderIndex IS NULL THEN 1 ELSE 0 END, t.orderIndex")
     List<Topic> findUnstartedTopicsForUser(@Param("userId") Long userId);
+
+    List<Topic> findAllByOrderIndexNotNullOrderByOrderIndexAsc();
+
+    List<Topic> findByOrderIndexIsNullOrderByNameAsc();
 
     Optional<Topic> findByName(String name);
 }

--- a/src/main/java/com/example/duolingomathbot/service/UserTrainingService.java
+++ b/src/main/java/com/example/duolingomathbot/service/UserTrainingService.java
@@ -236,13 +236,38 @@ public class UserTrainingService {
     }
 
     @Transactional
-    public Topic createTopic(String name) {
+    public Topic createTopic(String name, TopicType type) {
         if (topicRepository.findByName(name).isPresent()) {
             throw new IllegalArgumentException("Topic already exists: " + name);
         }
         Topic topic = new Topic();
         topic.setName(name);
+        topic.setType(type);
         topic.setMaxDifficultyInTopic(1.0);
         return topicRepository.save(topic);
+    }
+
+    @Transactional
+    public void updateTopicOrder(List<Long> orderedIds) {
+        List<Topic> all = topicRepository.findAll();
+        for (Topic t : all) {
+            int index = orderedIds.indexOf(t.getId());
+            if (index >= 0) {
+                t.setOrderIndex(index);
+            } else {
+                t.setOrderIndex(null);
+            }
+        }
+        topicRepository.saveAll(all);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Topic> getOrderedTopics() {
+        return topicRepository.findAllByOrderIndexNotNullOrderByOrderIndexAsc();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Topic> getUnorderedTopics() {
+        return topicRepository.findByOrderIndexIsNullOrderByNameAsc();
     }
 }


### PR DESCRIPTION
## Summary
- extend `Topic` with `type` and `orderIndex`
- allow creating topics with specific type
- manage topic order and new topic creation via new `/managetopics` command
- update bot logic for new topic type while adding tasks

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6856ee0c3a288326b1bdedf4149312b9