### PR TITLE
Fix topic management and cleanup

### DIFF
--- a/src/main/java/com/example/duolingomathbot/model/Topic.java
+++ b/src/main/java/com/example/duolingomathbot/model/Topic.java
@@ -11,16 +11,15 @@ public class Topic {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     @Column(name = "max_difficulty_in_topic", nullable = false)
     private double maxDifficultyInTopic = 1.0;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "varchar(8) default 'OBA'")
-
-    private TopicType type = TopicType.OBA;
+    @Column(nullable = false)
+    private TopicType type;
 
     @Column(name = "order_index")
     private Integer orderIndex;

--- a/src/main/java/com/example/duolingomathbot/model/TopicType.java
+++ b/src/main/java/com/example/duolingomathbot/model/TopicType.java
@@ -2,8 +2,7 @@ package com.example.duolingomathbot.model;
 
 public enum TopicType {
     OGE("ОГЭ"),
-    EGE("ЕГЭ"),
-    OBA("ОБА");
+    EGE("ЕГЭ");
 
     private final String displayName;
 

--- a/src/main/java/com/example/duolingomathbot/repository/TopicRepository.java
+++ b/src/main/java/com/example/duolingomathbot/repository/TopicRepository.java
@@ -1,6 +1,7 @@
 package com.example.duolingomathbot.repository;
 
 import com.example.duolingomathbot.model.Topic;
+import com.example.duolingomathbot.model.TopicType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,9 +14,11 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
             "ORDER BY CASE WHEN t.orderIndex IS NULL THEN 1 ELSE 0 END, t.orderIndex")
     List<Topic> findUnstartedTopicsForUser(@Param("userId") Long userId);
 
-    List<Topic> findAllByOrderIndexNotNullOrderByOrderIndexAsc();
+    List<Topic> findAllByTypeAndOrderIndexNotNullOrderByOrderIndexAsc(TopicType type);
 
-    List<Topic> findByOrderIndexIsNullOrderByNameAsc();
+    List<Topic> findByTypeAndOrderIndexIsNullOrderByNameAsc(TopicType type);
 
-    Optional<Topic> findByName(String name);
+    List<Topic> findByType(TopicType type);
+
+    Optional<Topic> findByNameAndType(String name, TopicType type);
 }

--- a/src/main/java/com/example/duolingomathbot/service/UserTrainingService.java
+++ b/src/main/java/com/example/duolingomathbot/service/UserTrainingService.java
@@ -237,8 +237,8 @@ public class UserTrainingService {
 
     @Transactional
     public Topic createTopic(String name, TopicType type) {
-        if (topicRepository.findByName(name).isPresent()) {
-            throw new IllegalArgumentException("Topic already exists: " + name);
+        if (topicRepository.findByNameAndType(name, type).isPresent()) {
+            throw new IllegalArgumentException("Topic already exists: " + name + " " + type);
         }
         Topic topic = new Topic();
         topic.setName(name);
@@ -248,9 +248,9 @@ public class UserTrainingService {
     }
 
     @Transactional
-    public void updateTopicOrder(List<Long> orderedIds) {
-        List<Topic> all = topicRepository.findAll();
-        for (Topic t : all) {
+    public void updateTopicOrder(List<Long> orderedIds, TopicType type) {
+        List<Topic> topicsOfType = topicRepository.findByType(type);
+        for (Topic t : topicsOfType) {
             int index = orderedIds.indexOf(t.getId());
             if (index >= 0) {
                 t.setOrderIndex(index);
@@ -258,16 +258,16 @@ public class UserTrainingService {
                 t.setOrderIndex(null);
             }
         }
-        topicRepository.saveAll(all);
+        topicRepository.saveAll(topicsOfType);
     }
 
     @Transactional(readOnly = true)
-    public List<Topic> getOrderedTopics() {
-        return topicRepository.findAllByOrderIndexNotNullOrderByOrderIndexAsc();
+    public List<Topic> getOrderedTopics(TopicType type) {
+        return topicRepository.findAllByTypeAndOrderIndexNotNullOrderByOrderIndexAsc(type);
     }
 
     @Transactional(readOnly = true)
-    public List<Topic> getUnorderedTopics() {
-        return topicRepository.findByOrderIndexIsNullOrderByNameAsc();
+    public List<Topic> getUnorderedTopics(TopicType type) {
+        return topicRepository.findByTypeAndOrderIndexIsNullOrderByNameAsc(type);
     }
 }


### PR DESCRIPTION
## Summary
- restrict `TopicType` to `OGE` and `EGE`
- store topic name without unique constraint and save per-exam order
- extend admin ordering workflow to choose exam type
- add ability to create both exam topics at once
- delete old inline-keyboard messages after interaction

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856fde760808326b8cd59120ea43c83