### PR TITLE
Add test creation and test taking features

### DIFF
--- a/src/main/java/com/example/duolingomathbot/model/Task.java
+++ b/src/main/java/com/example/duolingomathbot/model/Task.java
@@ -15,6 +15,10 @@ public class Task {
     @JoinColumn(name = "topic_id", nullable = false)
     private Topic topic;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "test_id")
+    private Test test;
+
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
@@ -49,6 +53,14 @@ public class Task {
 
     public void setTopic(Topic topic) {
         this.topic = topic;
+    }
+
+    public Test getTest() {
+        return test;
+    }
+
+    public void setTest(Test test) {
+        this.test = test;
     }
 
     public String getContent() {

--- a/src/main/java/com/example/duolingomathbot/model/Test.java
+++ b/src/main/java/com/example/duolingomathbot/model/Test.java
@@ -1,0 +1,58 @@
+package com.example.duolingomathbot.model;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "tests")
+public class Test {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "start_id", unique = true, nullable = false)
+    private int startId;
+
+    @Column(columnDefinition = "TEXT")
+    private String advice;
+
+    public Test() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public int getStartId() {
+        return startId;
+    }
+
+    public void setStartId(int startId) {
+        this.startId = startId;
+    }
+
+    public String getAdvice() {
+        return advice;
+    }
+
+    public void setAdvice(String advice) {
+        this.advice = advice;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Test test = (Test) o;
+        return Objects.equals(id, test.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/example/duolingomathbot/model/TopicType.java
+++ b/src/main/java/com/example/duolingomathbot/model/TopicType.java
@@ -2,7 +2,8 @@ package com.example.duolingomathbot.model;
 
 public enum TopicType {
     OGE("ОГЭ"),
-    EGE("ЕГЭ");
+    EGE("ЕГЭ"),
+    TEST("Тест");
 
     private final String displayName;
 

--- a/src/main/java/com/example/duolingomathbot/repository/TaskRepository.java
+++ b/src/main/java/com/example/duolingomathbot/repository/TaskRepository.java
@@ -2,6 +2,7 @@ package com.example.duolingomathbot.repository;
 
 import com.example.duolingomathbot.model.Task;
 import com.example.duolingomathbot.model.Topic;
+import com.example.duolingomathbot.model.Test;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -25,4 +26,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             "AND uta.nextReviewAtTraining = :trainingCounter " +
             "ORDER BY uta.attemptTimestamp DESC")
     List<Task> findTasksForReviewInTopic(@Param("userId") Long userId, @Param("topic") Topic topic, @Param("trainingCounter") int trainingCounter, Pageable pageable);
+
+    List<Task> findByTestOrderByIdAsc(Test test);
 }

--- a/src/main/java/com/example/duolingomathbot/repository/TestRepository.java
+++ b/src/main/java/com/example/duolingomathbot/repository/TestRepository.java
@@ -1,0 +1,14 @@
+package com.example.duolingomathbot.repository;
+
+import com.example.duolingomathbot.model.Test;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface TestRepository extends JpaRepository<Test, Long> {
+    Optional<Test> findByStartId(int startId);
+
+    @Query("select max(t.startId) from Test t")
+    Integer findMaxStartId();
+}


### PR DESCRIPTION
## Summary
- introduce entity `Test` and repository
- extend `TopicType` with `TEST`
- allow tasks to belong to tests
- create service methods for making and running tests
- support `/maketest` for admins and `/test` command for users

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6857139c844483268e402264d8a8637e