### PR TITLE
Add unit tests for services

### DIFF
--- a/src/test/java/com/example/duolingomathbot/service/MagnetServiceTest.java
+++ b/src/test/java/com/example/duolingomathbot/service/MagnetServiceTest.java
@@ -1,0 +1,49 @@
+import com.example.duolingomathbot.model.Magnet;
+import com.example.duolingomathbot.repository.MagnetRepository;
+import com.example.duolingomathbot.service.MagnetService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+class MagnetServiceTest {
+
+    private MagnetRepository magnetRepository;
+    private MagnetService magnetService;
+
+    @BeforeEach
+    void setUp() {
+        magnetRepository = Mockito.mock(MagnetRepository.class);
+        magnetService = new MagnetService(magnetRepository);
+    }
+
+    @Test
+    void createMagnetGeneratesAndSavesMagnet() {
+        when(magnetRepository.existsByStartId(anyInt())).thenReturn(false);
+        when(magnetRepository.save(any(Magnet.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Magnet result = magnetService.createMagnet("fileId", "message");
+
+        assertEquals("fileId", result.getFileId());
+        assertEquals("message", result.getMessage());
+        assertNotNull(result.getStartId());
+        verify(magnetRepository).save(any(Magnet.class));
+    }
+
+    @Test
+    void getByStartIdDelegatesToRepository() {
+        Magnet magnet = new Magnet();
+        when(magnetRepository.findByStartId(123)).thenReturn(Optional.of(magnet));
+
+        Optional<Magnet> result = magnetService.getByStartId(123);
+
+        assertTrue(result.isPresent());
+        assertSame(magnet, result.get());
+        verify(magnetRepository).findByStartId(123);
+    }
+}

--- a/src/test/java/com/example/duolingomathbot/service/UserTrainingServiceTest.java
+++ b/src/test/java/com/example/duolingomathbot/service/UserTrainingServiceTest.java
@@ -1,0 +1,68 @@
+import com.example.duolingomathbot.model.Task;
+import com.example.duolingomathbot.model.Topic;
+import com.example.duolingomathbot.model.TopicType;
+import com.example.duolingomathbot.model.User;
+import com.example.duolingomathbot.repository.*;
+import com.example.duolingomathbot.service.UserTrainingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+class UserTrainingServiceTest {
+
+    private UserRepository userRepository;
+    private TopicRepository topicRepository;
+    private TaskRepository taskRepository;
+    private TestRepository testRepository;
+    private UserTopicProgressRepository userTopicProgressRepository;
+    private UserTaskAttemptRepository userTaskAttemptRepository;
+    private UserTrainingService service;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = Mockito.mock(UserRepository.class);
+        topicRepository = Mockito.mock(TopicRepository.class);
+        taskRepository = Mockito.mock(TaskRepository.class);
+        testRepository = Mockito.mock(TestRepository.class);
+        userTopicProgressRepository = Mockito.mock(UserTopicProgressRepository.class);
+        userTaskAttemptRepository = Mockito.mock(UserTaskAttemptRepository.class);
+        service = new UserTrainingService(userRepository, topicRepository, taskRepository,
+                testRepository, userTopicProgressRepository, userTaskAttemptRepository);
+    }
+
+    @Test
+    void getOrCreateUserReturnsExisting() {
+        User user = new User(1L, "name");
+        when(userRepository.findByTelegramId(1L)).thenReturn(Optional.of(user));
+
+        User result = service.getOrCreateUser(1L, "name");
+
+        assertSame(user, result);
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void getOrCreateUserCreatesNewWhenMissing() {
+        when(userRepository.findByTelegramId(2L)).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User result = service.getOrCreateUser(2L, "new");
+
+        assertEquals(2L, result.getTelegramId());
+        assertEquals("new", result.getUsername());
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void isAnswerCorrectHandlesCaseAndSpaces() {
+        Task task = new Task();
+        task.setAnswer("Answer");
+        assertTrue(service.isAnswerCorrect(task, " answer "));
+        assertFalse(service.isAnswerCorrect(task, "wrong"));
+    }
+}


### PR DESCRIPTION
## Summary
- add MagnetServiceTest covering create and lookup logic
- add UserTrainingServiceTest verifying user creation and answer checking

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685718f28a4c8326ae85fd049bcb66be