### PR TITLE
Add test start links and random ids

### DIFF
--- a/src/main/java/com/example/duolingomathbot/repository/TestRepository.java
+++ b/src/main/java/com/example/duolingomathbot/repository/TestRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 public interface TestRepository extends JpaRepository<Test, Long> {
     Optional<Test> findByStartId(int startId);
+    boolean existsByStartId(int startId);
 
     @Query("select max(t.startId) from Test t")
     Integer findMaxStartId();

--- a/src/main/java/com/example/duolingomathbot/service/UserTrainingService.java
+++ b/src/main/java/com/example/duolingomathbot/service/UserTrainingService.java
@@ -279,10 +279,12 @@ public class UserTrainingService {
 
     @Transactional
     public Test createTest() {
-        Integer max = testRepository.findMaxStartId();
-        int next = (max == null ? 10000 : Math.max(10000, max + 1));
+        int startId;
+        do {
+            startId = 10000 + random.nextInt(90000);
+        } while (testRepository.existsByStartId(startId));
         Test test = new Test();
-        test.setStartId(next);
+        test.setStartId(startId);
         return testRepository.save(test);
     }
 

--- a/src/test/java/com/example/duolingomathbot/service/UserTrainingServiceTest.java
+++ b/src/test/java/com/example/duolingomathbot/service/UserTrainingServiceTest.java
@@ -126,4 +126,17 @@ class UserTrainingServiceTest {
         assertThrows(IllegalArgumentException.class,
                 () -> service.addTask(2L, "c", "a"));
     }
+
+    @Test
+    void createTestGeneratesStartIdInRange() {
+        when(testRepository.existsByStartId(anyInt())).thenReturn(false);
+        when(testRepository.save(any(com.example.duolingomathbot.model.Test.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        com.example.duolingomathbot.model.Test test = service.createTest();
+
+        assertTrue(test.getStartId() >= 10000 && test.getStartId() <= 99999);
+        verify(testRepository).existsByStartId(test.getStartId());
+        verify(testRepository).save(any(com.example.duolingomathbot.model.Test.class));
+    }
 }


### PR DESCRIPTION
## Summary
- ensure each new test gets a random start id in the 10000–99999 range
- provide Telegram link to created test
- allow `/start <id>` to open tests in addition to magnets
- unit test for random start id generation

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68572c5d434c8326acaf7569186a3644