### PR TITLE
Allow configuring admin chat ID

### DIFF
--- a/src/main/java/com/example/duolingomathbot/bot/BotConfig.java
+++ b/src/main/java/com/example/duolingomathbot/bot/BotConfig.java
@@ -34,4 +34,8 @@ public class BotConfig {
     public String getBotToken() {
         return botToken;
     }
+
+    public long getAdminChatId() {
+        return adminChatId;
+    }
 }

--- a/src/main/java/com/example/duolingomathbot/bot/MathSrTelegramBot.java
+++ b/src/main/java/com/example/duolingomathbot/bot/MathSrTelegramBot.java
@@ -69,7 +69,7 @@ public class MathSrTelegramBot extends TelegramLongPollingBot {
 
     private final ConcurrentHashMap<Long, TrainingSession> userSessions = new ConcurrentHashMap<>();
 
-    private static final long ADMIN_CHAT_ID = 262398881L;
+    private final long adminChatId;
 
     private enum AddTaskStep {
         WAITING_FOR_PHOTO,
@@ -151,6 +151,7 @@ public class MathSrTelegramBot extends TelegramLongPollingBot {
         this.botConfig = botConfig;
         this.userTrainingService = userTrainingService;
         this.magnetService = magnetService;
+        this.adminChatId = botConfig.getAdminChatId();
     }
 
     @Override
@@ -324,7 +325,7 @@ public class MathSrTelegramBot extends TelegramLongPollingBot {
         }
 
         if ("/addtask".equals(messageText)) {
-            if (chatId != ADMIN_CHAT_ID) {
+            if (chatId != adminChatId) {
                 sendMessage(chatId, "Команда доступна только администратору");
                 return;
             }
@@ -336,7 +337,7 @@ public class MathSrTelegramBot extends TelegramLongPollingBot {
         }
 
         if ("/makemagnet".equals(messageText)) {
-            if (chatId != ADMIN_CHAT_ID) {
+            if (chatId != adminChatId) {
                 sendMessage(chatId, "Команда доступна только администратору");
                 return;
             }
@@ -348,7 +349,7 @@ public class MathSrTelegramBot extends TelegramLongPollingBot {
         }
 
         if ("/managetopics".equals(messageText)) {
-            if (chatId != ADMIN_CHAT_ID) {
+            if (chatId != adminChatId) {
                 sendMessage(chatId, "Команда доступна только администратору");
                 return;
             }
@@ -360,7 +361,7 @@ public class MathSrTelegramBot extends TelegramLongPollingBot {
         }
 
         if ("/maketest".equals(messageText)) {
-            if (chatId != ADMIN_CHAT_ID) {
+            if (chatId != adminChatId) {
                 sendMessage(chatId, "Команда доступна только администратору");
                 return;
             }
@@ -388,7 +389,7 @@ public class MathSrTelegramBot extends TelegramLongPollingBot {
         }
 
         if ("/finishmarathon".equals(messageText)) {
-            if (chatId != ADMIN_CHAT_ID) {
+            if (chatId != adminChatId) {
                 sendMessage(chatId, "Команда доступна только администратору");
                 return;
             }


### PR DESCRIPTION
## Summary
- wire Telegram admin chat id from properties via `BotConfig`
- use injected value in `MathSrTelegramBot`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685803e601a0832692e8424d1bbf18e4