### PR TITLE
Add /getfileid admin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ These correspond to the properties `spring.datasource.*` and `telegram.bot.*` in
 java -jar build/libs/duolingomathbot-0.0.1-SNAPSHOT.jar
 ```
 
-When the application starts, it registers the Telegram bot and you can interact with it through the usual bot commands (`/start`, `/train`, `/cancel`, etc.).
+When the application starts, it registers the Telegram bot and you can interact with it through the usual bot commands (`/start`, `/train`, `/cancel`, etc.). Administrators can also use `/getfileid` to obtain a `fileId` for any sent file.


### PR DESCRIPTION
## Summary
- add `/getfileid` admin command for retrieving file IDs
- implement file-id state tracking and markdown response
- register command and document usage in README

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68580695b3308326adb916fea967395f