### PR TITLE
Configure scheduler thread pool

### DIFF
--- a/src/main/java/com/example/duolingomathbot/config/SchedulerConfig.java
+++ b/src/main/java/com/example/duolingomathbot/config/SchedulerConfig.java
@@ -1,0 +1,23 @@
+package com.example.duolingomathbot.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * Configures a dedicated thread pool for scheduled tasks so that reading
+ * Google Sheets does not block the main thread.
+ */
+@Configuration
+public class SchedulerConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.setThreadNamePrefix("schedule-");
+        scheduler.initialize();
+        return scheduler;
+    }
+}


### PR DESCRIPTION
## Summary
- create `SchedulerConfig` with a custom `ThreadPoolTaskScheduler`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685811b79a7c8326be82d6c7913dcbcc